### PR TITLE
EventListener::listens_to API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -507,7 +507,7 @@ impl EventListener {
     /// ```
     #[inline]
     pub fn listens_to(&self, event: &Event) -> bool {
-        ptr::eq(&*self.inner, event.inner.load(Ordering::Relaxed))
+        ptr::eq(&*self.inner, event.inner.load(Ordering::Acquire))
     }
 
     fn wait_internal(mut self, deadline: Option<Instant>) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@ use std::future::Future;
 use std::mem::{self, ManuallyDrop};
 use std::ops::{Deref, DerefMut};
 use std::pin::Pin;
-use std::ptr::NonNull;
+use std::ptr::{self, NonNull};
 use std::sync::atomic::{self, AtomicPtr, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::task::{Context, Poll, Waker};
@@ -491,6 +491,23 @@ impl EventListener {
     /// ```
     pub fn wait_deadline(self, deadline: Instant) -> bool {
         self.wait_internal(Some(deadline))
+    }
+
+    /// Returns true if this listener listens to this event.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use event_listener::Event;
+    ///
+    /// let event = Event::new();
+    /// let listener = event.listen();
+    ///
+    /// assert!(listener.listens_to(&event));
+    /// ```
+    #[inline]
+    pub fn listens_to(&self, event: &Event) -> bool {
+        ptr::eq(&*self.inner, event.inner.load(Ordering::Relaxed))
     }
 
     fn wait_internal(mut self, deadline: Option<Instant>) -> bool {


### PR DESCRIPTION
This is an API for returning whether or not an event listener listens to a given event. This is useful if you want a handle that could be stored in multiple event listener queues over the course of its lifetime, and you need to know which one it is. Otherwise, the handle has to track that state additionally.

I'm not sure about the API surface, so tell me how you think it should look. Right now its just a method on EventListener that takes a reference to an event.

There's also a reasonable desire to have a method that takes another EventListener, and returns whether or not these two listeners listen to the same event.